### PR TITLE
Update insertParts() to insert parts much faster #1

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -197,12 +197,12 @@ function insertParts() {
 		dataSource: clusterName,
 	}
 
-	  const options = {
+	const options = {
 		method: "post",
 		contentType: "application/json",
 		payload: JSON.stringify(payload),
 		headers: { "api-key": apiKey },
-	  }
+	}
   
 	// make sure partsToInsert isn't empty
 	if (partsToInsert.length > 0) {

--- a/src/main.js
+++ b/src/main.js
@@ -35,38 +35,38 @@ const columnVals = [
 
 function getAllBarcodes() {
 
-  var sheet = SpreadsheetApp.getActiveSheet()
-  var data = sheet.getDataRange().getValues()
+	var sheet = SpreadsheetApp.getActiveSheet()
+	var data = sheet.getDataRange().getValues()
 
-  // create endpoint to find all parts
-  const findEndpoint = endpoint + "/action/find"
+	// create endpoint to find all parts
+	const findEndpoint = endpoint + "/action/find"
 
-  const payload = {
-    collection: collectionName,
-    database: databaseName,
-    dataSource: clusterName
-  }
+	const payload = {
+		collection: collectionName,
+		database: databaseName,
+		dataSource: clusterName
+	}
 
-  const options = {
-    method: 'post',
-    contentType: 'application/json',
-    payload: JSON.stringify(payload),
-    headers: { "api-key": apiKey }
-  }
-  const response = UrlFetchApp.fetch(findEndpoint, options);
+	const options = {
+		method: 'post',
+		contentType: 'application/json',
+		payload: JSON.stringify(payload),
+		headers: { "api-key": apiKey }
+	}
+	const response = UrlFetchApp.fetch(findEndpoint, options);
 
-  // parse response object to a JS Object
-  const parsedResponse = JSON.parse(response.getContentText())
-  
-  const allParts = parsedResponse.documents
-  
-  // add barcodes to a set for constant time lookup
-  const barcodes = new Set()
-  for (let i = 0; i < allParts.length; i++) {
-    barcodes.add(allParts[i].barcode)
-  }
+	// parse response object to a JS Object
+	const parsedResponse = JSON.parse(response.getContentText())
 
-  return barcodes
+	const allParts = parsedResponse.documents
+
+	// add barcodes to a set for constant time lookup
+	const barcodes = new Set()
+	for (let i = 0; i < allParts.length; i++) {
+		barcodes.add(allParts[i].barcode)
+	}
+
+	return barcodes
 
 }
 
@@ -190,32 +190,31 @@ function insertParts() {
 		}
 	}
 
-  const payload = {
-    documents: partsToInsert,
-    collection: collectionName,
-    database: databaseName,
-    dataSource: clusterName,
-  }
+	const payload = {
+		documents: partsToInsert,
+		collection: collectionName,
+		database: databaseName,
+		dataSource: clusterName,
+	}
 
-  const options = {
-    method: "post",
-    contentType: "application/json",
-    payload: JSON.stringify(payload),
-    headers: { "api-key": apiKey },
-  }
+	  const options = {
+		method: "post",
+		contentType: "application/json",
+		payload: JSON.stringify(payload),
+		headers: { "api-key": apiKey },
+	  }
   
-  // make sure partsToInsert isn't empty
-  if (partsToInsert.length > 0) {
-    const response = UrlFetchApp.fetch(insertEndpoint, options)    
-  }
-  
+	// make sure partsToInsert isn't empty
+	if (partsToInsert.length > 0) {
+		const response = UrlFetchApp.fetch(insertEndpoint, options)    
+	}
+
 	if (duplicateParts.length === 0) {
 		SpreadsheetApp.getUi().alert("Success! All parts added!")
-	} else {
-		SpreadsheetApp.getUi().alert(
-			"Duplicate parts in rows: " + duplicateParts + "\nNon-duplicate items were inserted successfully"
-		)
-	}   
+	} 
+	else {
+		SpreadsheetApp.getUi().alert("Duplicate parts in rows: " + duplicateParts + "\nNon-duplicate items were inserted successfully")
+	}
 }
 
 function clearSheet() {


### PR DESCRIPTION
Previously, we used the actions/insertOne endpoint to insert each part one by one, while checking with the database to see if the part we're inserting was already in the database.

With this speedier implementation, the getAllBarcodes() function takes all the barcodes from the database and put them in a set. So instead of inserting one part at a time and checking if the part's barcode exists in the mongo database, we check if the barcode is in the set and adding non-duplicates to a separate list to be inserted using actions/insertMany.
This allows for much faster insertion times and fewer calls to the mongo data api.

TLDR:
Much faster parts insertion.